### PR TITLE
Hacked a bit on the new notebook performance tests.

### DIFF
--- a/types2.ipynb
+++ b/types2.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -42,6 +42,32 @@
     "\n",
     "oldag = u.atoms[idx]\n",
     "newag = master[idx]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "oldag_full = u.atoms\n",
+    "newag_full = atomtypes.convert(u.atoms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# since the processor cache will affect the speeds of repeated access,\n",
+    "# we want to take only the cached calls and leave off the slow ones for our\n",
+    "# timing runs so we can at least compare consistently\n",
+    "percentile = .75"
    ]
   },
   {
@@ -62,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -71,23 +97,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 50: 6.39 ms per loop\n",
-      "1 loops, best of 50: 95.9 ms per loop\n",
-      "New style took: 0.00679092204317\n",
-      "Old style took: 0.0963716101139\n",
+      "1 loops, best of 50: 7.57 ms per loop\n",
+      "1 loops, best of 50: 173 ms per loop\n",
+      "New style took: 0.00763145652977\n",
+      "Old style took: 0.174694370579\n",
       "\n",
-      "Speed up of new: 14.1912408214\n"
+      "Speed up of new: 22.8913536882\n"
      ]
     }
    ],
    "source": [
     "a_new = %timeit -n1 -r50 -o newag.names()\n",
     "s_new = pd.Series(a_new.all_runs)\n",
-    "t_new = s_new[s_new < s_new.quantile(.95)].mean()\n",
+    "t_new = s_new[s_new < s_new.quantile(percentile)].mean()\n",
     "\n",
     "a_old = %timeit -n1 -r50 -o oldag.names()\n",
     "s_old = pd.Series(a_old.all_runs)\n",
-    "t_old = s_old[s_old < s_old.quantile(.95)].mean()\n",
+    "t_old = s_old[s_old < s_old.quantile(percentile)].mean()\n",
     "\n",
     "print \"New style took: {}\".format(t_new)\n",
     "print \"Old style took: {}\".format(t_old)\n",
@@ -104,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -113,23 +139,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 50: 3.98 ms per loop\n",
-      "1 loops, best of 50: 45.5 ms per loop\n",
-      "New style took: 0.00428470144881\n",
-      "Old style took: 0.0457718879619\n",
+      "1 loops, best of 50: 4.96 ms per loop\n",
+      "1 loops, best of 50: 74.7 ms per loop\n",
+      "New style took: 0.00501285372554\n",
+      "Old style took: 0.0753132394842\n",
       "\n",
-      "Speed up of new: 10.6826318026\n"
+      "Speed up of new: 15.0240249582\n"
      ]
     }
    ],
    "source": [
     "a_new = %timeit -n1 -r50 -o newag.charges()\n",
     "s_new = pd.Series(a_new.all_runs)\n",
-    "t_new = s_new[s_new < s_new.quantile(.95)].mean()\n",
+    "t_new = s_new[s_new < s_new.quantile(percentile)].mean()\n",
     "\n",
     "a_old = %timeit -n1 -r50 -o oldag.charges()\n",
     "s_old = pd.Series(a_old.all_runs)\n",
-    "t_old = s_old[s_old < s_old.quantile(.95)].mean()\n",
+    "t_old = s_old[s_old < s_old.quantile(percentile)].mean()\n",
     "\n",
     "print \"New style took: {}\".format(t_new)\n",
     "print \"Old style took: {}\".format(t_old)\n",
@@ -146,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -155,12 +181,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 50: 5.61 ms per loop\n",
-      "1 loops, best of 50: 88.9 ms per loop\n",
-      "New style took: 0.00579103510431\n",
-      "Old style took: 0.0901888735751\n",
+      "1 loops, best of 50: 3.99 ms per loop\n",
+      "1 loops, best of 50: 151 ms per loop\n",
+      "New style took: 0.00402729575698\n",
+      "Old style took: 0.158945309149\n",
       "\n",
-      "Speed up of new: 15.5738778907\n"
+      "Speed up of new: 39.4670068305\n"
      ]
     }
    ],
@@ -169,11 +195,11 @@
     "\n",
     "a_new = %timeit -n1 -r50 -o newag.set_charges(charges)\n",
     "s_new = pd.Series(a_new.all_runs)\n",
-    "t_new = s_new[s_new < s_new.quantile(.95)].mean()\n",
+    "t_new = s_new[s_new < s_new.quantile(percentile)].mean()\n",
     "\n",
     "a_old = %timeit -n1 -r50 -o oldag.set_charge(charges)\n",
     "s_old = pd.Series(a_old.all_runs)\n",
-    "t_old = s_old[s_old < s_old.quantile(.95)].mean()\n",
+    "t_old = s_old[s_old < s_old.quantile(percentile)].mean()\n",
     "\n",
     "print \"New style took: {}\".format(t_new)\n",
     "print \"Old style took: {}\".format(t_old)\n",
@@ -190,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -199,13 +225,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The slowest run took 6.31 times longer than the fastest. This could mean that an intermediate result is being cached \n",
-      "1 loops, best of 50: 68.9 µs per loop\n",
-      "1 loops, best of 50: 4.19 ms per loop\n",
-      "New style took: 8.04890977575e-05\n",
-      "Old style took: 0.00480854764898\n",
+      "The slowest run took 9.00 times longer than the fastest. This could mean that an intermediate result is being cached \n",
+      "1 loops, best of 50: 102 µs per loop\n",
+      "1 loops, best of 50: 5.79 ms per loop\n",
+      "New style took: 0.000199026531643\n",
+      "Old style took: 0.00595336347013\n",
       "\n",
-      "Speed up of new: 59.7416020672\n"
+      "Speed up of new: 29.9124112799\n"
      ]
     }
    ],
@@ -214,11 +240,55 @@
     "\n",
     "a_new = %timeit -n1 -r50 -o newag[idx2]\n",
     "s_new = pd.Series(a_new.all_runs)\n",
-    "t_new = s_new[s_new < s_new.quantile(.95)].mean()\n",
+    "t_new = s_new[s_new < s_new.quantile(percentile)].mean()\n",
     "\n",
     "a_old = %timeit -n1 -r50 -o oldag[idx2]\n",
     "s_old = pd.Series(a_old.all_runs)\n",
-    "t_old = s_old[s_old < s_old.quantile(.95)].mean()\n",
+    "t_old = s_old[s_old < s_old.quantile(percentile)].mean()\n",
+    "\n",
+    "print \"New style took: {}\".format(t_new)\n",
+    "print \"Old style took: {}\".format(t_old)\n",
+    "print \"\"\n",
+    "print \"Speed up of new: {}\".format(t_old / t_new)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What about fancy indexing the full set of atoms? Does the relative speedup depend on system size?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loops, best of 50: 1.05 ms per loop\n",
+      "1 loops, best of 50: 22.7 ms per loop\n",
+      "New style took: 0.00110406488986\n",
+      "Old style took: 0.0233755240569\n",
+      "\n",
+      "Speed up of new: 21.1722374941\n"
+     ]
+    }
+   ],
+   "source": [
+    "idx2 = np.random.randint(0, len(oldag_full), size=25000)\n",
+    "\n",
+    "a_new = %timeit -n1 -r50 -o newag_full[idx2].names()\n",
+    "s_new = pd.Series(a_new.all_runs)\n",
+    "t_new = s_new[s_new < s_new.quantile(percentile)].mean()\n",
+    "\n",
+    "a_old = %timeit -n1 -r50 -o oldag_full[idx2].names()\n",
+    "s_old = pd.Series(a_old.all_runs)\n",
+    "t_old = s_old[s_old < s_old.quantile(percentile)].mean()\n",
     "\n",
     "print \"New style took: {}\".format(t_new)\n",
     "print \"Old style took: {}\".format(t_old)\n",
@@ -242,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -251,38 +321,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 50: 11.6 ms per loop\n",
-      "1 loops, best of 50: 114 ms per loop\n",
-      "New style took :0.0121068599376\n",
-      "Old style took :0.115407471961\n",
+      "1 loops, best of 50: 12.6 ms per loop\n",
+      "1 loops, best of 50: 198 ms per loop\n",
+      "New style took :0.0126413976824\n",
+      "Old style took :0.198858480196\n",
       "\n",
-      "Speed up of new: 9.53240332801\n"
+      "Speed up of new: 15.7307352551\n"
      ]
     }
    ],
    "source": [
     "a_new = %timeit -n1 -r50 -o newag[newag.names() == 'OW']\n",
     "s_new = pd.Series(a_new.all_runs)\n",
-    "t_new = s_new[s_new < s_new.quantile(.95)].mean()\n",
+    "t_new = s_new[s_new < s_new.quantile(percentile)].mean()\n",
     "\n",
     "a_old = %timeit -n1 -r50 -o oldag[oldag.names() == 'OW']\n",
     "s_old = pd.Series(a_old.all_runs)\n",
-    "t_old = s_old[s_old < s_old.quantile(.95)].mean()\n",
+    "t_old = s_old[s_old < s_old.quantile(percentile)].mean()\n",
     "\n",
     "print \"New style took :{}\".format(t_new)\n",
     "print \"Old style took :{}\".format(t_old)\n",
     "print \"\"\n",
     "print \"Speed up of new: {}\".format(t_old/t_new)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -301,7 +362,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Tried out fancy indexing on the full set of atoms and seeing speedup
that we didn't see before. This works because the resulting AtomGroup
only stores the indexes for the rows in the master table its atoms
correspond to; it doesn't do any fancy indexing on the table until
one calls a method or property, such as names() or charges(). What's
more, for these cases it only has to slice a column of the array
to get these, returning only a copy of the underlying data and only
that data (not the whole rows), which appears to be quite fast.
